### PR TITLE
Add the ability to explicitly name the font stack; upgrade freetype.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbf_font_tools"
-version = "2.1.0"
+version = "2.2.0"
 authors = ["Ian Wagner <ian@stadiamaps.com>", "Luke Seelenbinder <luke@stadiamaps.com>"]
 license = "BSD-3-Clause"
 repository = "https://github.com/stadiamaps/pbf_font_tools"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = "Tools for working with SDF font glyphs encoded in protobuf format
 keywords = ["sdf", "protobuf", "fonts"]
 categories = ["encoding", "parsing", "rendering::data-formats"]
 edition = "2021"
+exclude = [".github/"]
 
 [features]
 freetype = ["freetype-rs", "sdf_glyph_renderer/freetype"]
@@ -31,9 +32,7 @@ version = "0.31.0"
 optional = true
 
 [dependencies.sdf_glyph_renderer]
-#version = "0.3.0"
-git = "https://github.com/stadiamaps/sdf_glyph_renderer"
-branch = "upgrade-freetype"
+version = "0.4.0"
 optional = true
 
 [dev-dependencies.tokio]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,13 @@ protobuf-codegen = "3.0.3"
 protoc-bin-vendored = "3.0.0"
 
 [dependencies.freetype-rs]
-version = "0.30.1"
+version = "0.31.0"
 optional = true
 
 [dependencies.sdf_glyph_renderer]
-version = "0.3.0"
+#version = "0.3.0"
+git = "https://github.com/stadiamaps/sdf_glyph_renderer"
+branch = "upgrade-freetype"
 optional = true
 
 [dev-dependencies.tokio]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,10 @@ type GlyphResult = Result<glyphs::Glyphs, protobuf::Error>;
 /// See the documentation for `combine_glyphs` for further details.
 /// Unlike `combine_glyphs`, the result of this method will always contain a `glyphs` message,
 /// even if the loaded range is empty for a given font.
-pub async fn get_font_stack(
+pub async fn get_named_font_stack(
     font_path: &Path,
     font_names: &[&str],
+    stack_name: String,
     start: u32,
     end: u32,
 ) -> GlyphResult {
@@ -53,12 +54,22 @@ pub async fn get_font_stack(
             let mut result = glyphs::Glyphs::new();
 
             let mut stack = glyphs::Fontstack::new();
-            stack.set_name(font_names.join(", "));
+            stack.set_name(stack_name);
             stack.set_range(format!("{start}-{end}"));
 
             result.stacks.push(stack);
             result
         }))
+}
+
+pub async fn get_font_stack(
+    font_path: &Path,
+    font_names: &[&str],
+    start: u32,
+    end: u32,
+) -> GlyphResult {
+    let stack_name = font_names.join(", ");
+    get_named_font_stack(font_path, font_names, stack_name, start, end).await
 }
 
 /// Loads a single font PBF slice from disk.


### PR DESCRIPTION
Depends on https://github.com/stadiamaps/sdf_glyph_renderer/pull/4. Once that's merged, I'll update `Cargo.toml`.